### PR TITLE
Tighten input validation rules for CSP data

### DIFF
--- a/csp-reporter.py
+++ b/csp-reporter.py
@@ -70,15 +70,12 @@ def generate_report(data):
         csp_report[prop] = ''
 
     try:
-        csp_report_data = json.loads(data)
-    except json.decoder.JSONDecodeError:
-        return None, 400
-    except:
+        csp_report_data = json.loads(data)['csp-report']
+    except Exception:
         return None, 400
 
-    if not 'csp-report' in csp_report_data:
+    if not isinstance(csp_report_data, dict):
         return None, 400
-    csp_report_data = csp_report_data['csp-report']
 
     if is_exception(csp_report_data):
         return None, 204


### PR DESCRIPTION
The input may be invalid for several reasons:

- the data cannot be decoded as JSON (this was handled)
- the decoded data may not be a dictionary
- the decoded data may be missing the "csp-report" property (this was
  handled)
- the "csp-report" property may not be a dictionary